### PR TITLE
fs_mgr: Change f2fs path

### DIFF
--- a/fs_mgr/fs_mgr_format.c
+++ b/fs_mgr/fs_mgr_format.c
@@ -74,7 +74,7 @@ static int format_f2fs(char *fs_blkdev, long long fs_length)
     int rc = 0;
     char buff[65];
 
-    args[0] = (char *)"/sbin/mkfs.f2fs";
+    args[0] = (char *)"/system/bin/mkfs.f2fs";
 
     if (fs_length >= 0) {
         snprintf(buff, sizeof(buff), "%lld", fs_length / 512);
@@ -95,7 +95,7 @@ static int format_f2fs(char *fs_blkdev, long long fs_length)
     }
     if (!pid) {
         /* This doesn't return */
-        execv("/sbin/mkfs.f2fs", args);
+        execv("/system/bin/mkfs.f2fs", args);
         exit(1);
     }
     for(;;) {


### PR DESCRIPTION
Fix if data partition is wiped, it won't format itself during bootup.
Since f2fs path has been changed to /system/bin in M instead of /sbin

Change-Id: Ic111487d2c5d91da385f2292205abd011128d17d
