### PR TITLE
Revert "fs_mgr: let fsck.f2fs actually attempt a fix"

### DIFF
--- a/fs_mgr/fs_mgr.c
+++ b/fs_mgr/fs_mgr.c
@@ -161,12 +161,12 @@ static void check_fs(char *blk_device, char *fs_type, char *target)
             }
         }
     } else if (!strcmp(fs_type, "f2fs")) {
-            char *f2fs_fsck_argv[] = {
-                    F2FS_FSCK_BIN,
-                    "-f",
-                    blk_device
-            };
-        INFO("Running %s -f %s\n", F2FS_FSCK_BIN, blk_device);
+        char *f2fs_fsck_argv[] = {
+            F2FS_FSCK_BIN,
+            "-a",
+            blk_device
+        };
+        INFO("Running %s on %s\n", F2FS_FSCK_BIN, blk_device);
 
         ret = android_fork_execvp_ext(ARRAY_SIZE(f2fs_fsck_argv), f2fs_fsck_argv,
                                       &status, true, LOG_KLOG | LOG_FILE,


### PR DESCRIPTION
fsck.f2fs will correctly fix when it's required, without the -f flag.

This reverts commit eb6036ac6be82dcc6e110de22574972631c8f83e.

Change-Id: Iec9ca5e593b61f24b02db30bff7089fafee7635e
Reviewed-on: http://gerrit.mot.com/721774
SLTApproved: Slta Waiver sltawvr@motorola.com
Tested-by: Jira Key jirakey@motorola.com
Reviewed-by: Christopher Fries cfries@motorola.com
Submit-Approved: Jira Key jirakey@motorola.com
